### PR TITLE
Add build automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,13 @@
 name: Build
-on: [push,workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+      - preview
+  release:
+    types:
+      - published
+  workflow_dispatch:
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -41,7 +49,7 @@ jobs:
               uses: softprops/action-gh-release@v2
               with:
                 files: tappdex.zip
-                draft: true
+                # draft: true
                 
     publish-pages:
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build
+on: [push,workflow_dispatch]
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repository code
+              uses: actions/checkout@v4
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: 22
+                cache: 'npm'
+            - run: npm ci
+            - name: Assets
+              uses: actions/cache@v4
+              with:
+                path: data
+                key: data-${{github.ref}}-${{hashFiles('data/**/*')}}
+                restore-keys: |
+                              data-${{github.ref}}
+                              data-main
+            - run: ./makeBundle.sh
+            - name: Archive production artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                name: tappdex
+                path: |
+                      dist
+    create-release:
+        runs-on: ubuntu-latest
+        needs: build
+        permissions:
+            contents: write
+        if: github.ref_type == 'tag' || github.ref_name == 'automation'
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                name: tappdex
+            - run: zip -r tappdex.zip *
+            - name: Create release
+              uses: softprops/action-gh-release@v2
+              with:
+                files: tappdex.zip
+                draft: true
+                
+    publish-pages:
+        runs-on: ubuntu-latest
+        needs: build
+        permissions:
+            id-token: write
+            pages: write
+        if: github.ref_name == 'preview' || github.ref_name == 'automation'
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                name: tappdex
+            - name: Upload pages content
+              uses: actions/upload-pages-artifact@v3
+              with:
+                path: .
+            - name: Deploy pages content
+              uses: actions/deploy-pages@v4
+                
+    
+                      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,8 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: data
-                key: data-${{github.ref}}-${{hashFiles('data/**/*')}}
+                key: data-${{github.ref_name}}
                 restore-keys: |
-                              data-${{github.ref}}
                               data-main
             - run: ./makeBundle.sh
             - name: Archive production artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 data
+dist
 *.zip

--- a/makeBundle.sh
+++ b/makeBundle.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
+mkdir dist
+mkdir dist/data
+mkdir dist/data/sprites
 
 node data.mjs
-zip tappdex.zip config.json icon.png index.html data/pokemon.json data/sprites/*
+cp data/pokemon.json dist/data/
+cp index.html dist/
+cp icon.png dist/
+cp config.json dist/
+cp data/sprites/* dist/data/sprites/
+
+#cd dist
+#zip ../tappdex.zip config.json icon.png index.html data/pokemon.json data/sprites/*
+#cd ..


### PR DESCRIPTION
Does two things:
* Upon publishing a new release, a build of tappdex will automatically be created and attached to it.
* Whenever the preview branch is updated, it will automatically update the Github Pages with the new version.